### PR TITLE
feat: server accepts PORT env or defaults to 3000

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -24,4 +24,5 @@ function start_listening(PORT) {
   });
 }
 
-run_server("mongodb://127.0.0.1:27017/myDatabase", 3000);
+const PORT = process.env.PORT || 3000;
+run_server("mongodb://127.0.0.1:27017/myDatabase", PORT);


### PR DESCRIPTION
I made this because I wanted to just type PORT=80 when running on the linux server.